### PR TITLE
Add a basic threshold for including documents in the returned message

### DIFF
--- a/document_finder.py
+++ b/document_finder.py
@@ -53,8 +53,12 @@ class DocumentFinder():
             cosine_similarities = cosine_similarity(vector, query_vec).flatten()
             most_similar_doc_indices = np.argsort(cosine_similarities, axis=0)[:-5-1:-1]
 
+            max_similarity = max(cosine_similarities)
             for index in most_similar_doc_indices:
-                if cosine_similarities[index] != 0:
+                # Only include document if the similarity score is at least 75% of the highest similarity score
+                # This means we return multiple documents when similar scores are seen, but only one when a document
+                # is a clear winner
+                if cosine_similarities[index] > max_similarity * 0.75:
                     doc_titles.append(file_list[index])
                 print('Similarity = {}'.format(cosine_similarities[index]))
                 print('file: {}, '.format(file_list[index]))

--- a/document_list.py
+++ b/document_list.py
@@ -8,7 +8,7 @@ class DocumentList:
         "text": {
             "type": "mrkdwn",
             "text": (
-                "I found the below docs that might be useful:"
+                "I found the below doc(s) that might be useful:"
             )
         }
     }


### PR DESCRIPTION
Adds a threshold that requires document similarities to be at least 75% of the most similar document in order to cut down on returning docs that are only very tangentially related to the query